### PR TITLE
Improve Titanic predictions with weighted ensemble

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
 # Simple baseline model for Kaggle Titanic competition
+import os
+import glob
 import pandas as pd
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
 from sklearn.impute import SimpleImputer
+from sklearn.model_selection import cross_val_score
 
 
 def load_data():
@@ -52,10 +55,29 @@ def preprocess_data(train_df, test_df):
 def train_and_predict(X, y, X_test, clf):
     clf.fit(X, y)
     predictions = clf.predict(X_test)
-    return predictions
+    probabilities = clf.predict_proba(X_test)[:, 1]
+    return predictions, probabilities
+
+
+def load_previous_submissions():
+    """Load historic submissions and their scores."""
+    scores_path = os.path.join('submissions', 'scores.csv')
+    if not os.path.exists(scores_path):
+        return []
+    scores_df = pd.read_csv(scores_path, sep=';')
+    submissions = []
+    for _, row in scores_df.iterrows():
+        sub_path = os.path.join('submissions', f"{row['Submission']}.csv")
+        if os.path.exists(sub_path):
+            df = pd.read_csv(sub_path)
+            submissions.append((row['Score'], df))
+    return submissions
 
 
 def save_submission(test_df, predictions, path='submission.csv'):
+    if isinstance(predictions, pd.Series):
+        predictions = predictions.values
+    predictions = predictions.astype(int)
     submission = pd.DataFrame({
         'PassengerId': test_df['PassengerId'],
         'Survived': predictions
@@ -66,8 +88,25 @@ def save_submission(test_df, predictions, path='submission.csv'):
 def main():
     train_df, test_df = load_data()
     X, y, X_test, clf = preprocess_data(train_df, test_df)
-    predictions = train_and_predict(X, y, X_test, clf)
-    save_submission(test_df, predictions)
+
+    # estimate baseline performance via cross validation
+    baseline_score = cross_val_score(clf, X, y, cv=5).mean()
+
+    predictions, probabilities = train_and_predict(X, y, X_test, clf)
+
+    submissions = load_previous_submissions()
+    if submissions:
+        total_weight = baseline_score
+        weighted = baseline_score * probabilities
+        for score, df in submissions:
+            df = df.set_index('PassengerId').loc[test_df['PassengerId']]
+            weighted += score * df['Survived']
+            total_weight += score
+        final_predictions = (weighted / total_weight >= 0.5).astype(int)
+    else:
+        final_predictions = predictions
+
+    save_submission(test_df, final_predictions)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- implement an ensemble that uses previous submission files and their scores
- compute baseline score via cross validation and weight predictions accordingly

## Testing
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6859ec70e7cc832597b8853c2491148c